### PR TITLE
feat: add media capture policies and geolocation API key

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -30,6 +30,9 @@ cp config.json.example ~/.config/xiboplayer/chromium/config.json
   // CMS transport: "auto" (default) or "xmds" (force SOAP for unpatched Xibo CMS)
   "transport": "auto",
 
+  // Google Geolocation API key (optional, improves location accuracy)
+  "googleGeoApiKey": "",
+
   // Keyboard and mouse controls
   "controls": {
     "keyboard": {
@@ -53,6 +56,22 @@ cp config.json.example ~/.config/xiboplayer/chromium/config.json
 | `"xmds"` | Force SOAP/XMDS transport — use this for unpatched Xibo CMS without REST API |
 
 Omitting `transport` or setting it to any value other than `"xmds"` uses auto-detection.
+
+## Google Geolocation API Key
+
+Optional. Improves location accuracy from ~5 km (IP-based fallback) to ~50 m (Google API).
+
+```json
+{
+  "googleGeoApiKey": "AIzaSy..."
+}
+```
+
+The key is passed to the SDK via `playerConfig`. Without it, the player falls back to free IP-based geolocation providers — no key required.
+
+## Media Capture
+
+Webcam and microphone access is auto-approved via Chromium enterprise policies. The kiosk launch script writes `VideoCaptureAllowed`, `AudioCaptureAllowed`, and URL restrictions limiting capture to `localhost` only. No configuration needed.
 
 ## Controls
 

--- a/xiboplayer/config.json.example
+++ b/xiboplayer/config.json.example
@@ -9,6 +9,8 @@
 
   "transport": "auto",
 
+  "googleGeoApiKey": "",
+
   "controls": {
     "keyboard": {
       "debugOverlays": false,

--- a/xiboplayer/launch-kiosk.sh
+++ b/xiboplayer/launch-kiosk.sh
@@ -41,6 +41,7 @@ if [[ -f "$CONFIG_FILE" ]]; then
     EXTRA_BROWSER_FLAGS=$(jq -r '.extraBrowserFlags // empty' "$CONFIG_FILE" 2>/dev/null) || true
     CONFIG_PORT=$(jq -r '.serverPort // empty' "$CONFIG_FILE" 2>/dev/null) || true
     [[ -n "$CONFIG_PORT" ]] && SERVER_PORT="$CONFIG_PORT"
+    GOOGLE_GEO_API_KEY=$(jq -r '.googleGeoApiKey // empty' "$CONFIG_FILE" 2>/dev/null) || true
 else
     # First run — create config directory (PWA setup page handles CMS registration)
     mkdir -p "$CONFIG_DIR"
@@ -71,6 +72,7 @@ if [[ -n "$INSTANCE" ]]; then
         [[ -n "$CONFIG_PORT" ]] && SERVER_PORT="$CONFIG_PORT"
         BROWSER=$(jq -r '.browser // "chromium"' "$CONFIG_FILE" 2>/dev/null) || true
         EXTRA_BROWSER_FLAGS=$(jq -r '.extraBrowserFlags // empty' "$CONFIG_FILE" 2>/dev/null) || true
+        GOOGLE_GEO_API_KEY=$(jq -r '.googleGeoApiKey // empty' "$CONFIG_FILE" 2>/dev/null) || true
     else
         mkdir -p "$CONFIG_DIR"
     fi
@@ -324,7 +326,7 @@ main() {
     [[ -n "$INSTANCE" ]] && data_suffix="chromium-${INSTANCE}"
     local data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/xiboplayer/${data_suffix}"
     mkdir -p "$data_dir/policies/managed" 2>/dev/null || true
-    cat > "$data_dir/policies/managed/kiosk.json" << 'POLICY'
+    cat > "$data_dir/policies/managed/kiosk.json" << POLICY
 {
   "TranslateEnabled": false,
   "AutoFillEnabled": false,
@@ -333,9 +335,19 @@ main() {
   "MetricsReportingEnabled": false,
   "SpellCheckServiceEnabled": false,
   "DownloadRestrictions": 3,
-  "DefaultGeolocationSetting": 1
+  "DefaultGeolocationSetting": 1,
+  "VideoCaptureAllowed": true,
+  "AudioCaptureAllowed": true,
+  "VideoCaptureAllowedUrls": ["http://localhost:${SERVER_PORT}"],
+  "AudioCaptureAllowedUrls": ["http://localhost:${SERVER_PORT}"]
 }
 POLICY
+
+    # Export Google Geolocation API key for the SDK (if configured)
+    if [[ -n "${GOOGLE_GEO_API_KEY:-}" ]]; then
+        export GOOGLE_GEO_API_KEY
+        echo "[xiboplayer]   Geo API: configured" >&2
+    fi
 
     # Build arguments and launch
     build_chromium_args

--- a/xiboplayer/server/server.js
+++ b/xiboplayer/server/server.js
@@ -51,6 +51,10 @@ try {
     playerConfig.transport = config.transport;
     console.log(`[Server] Transport: ${config.transport}`);
   }
+  if (config.googleGeoApiKey) {
+    playerConfig.googleGeoApiKey = config.googleGeoApiKey;
+    console.log(`[Server] Google Geolocation API key: configured`);
+  }
 } catch (err) {
   if (err.code !== 'ENOENT') {
     console.warn(`[Server] Failed to read config: ${err.message}`);


### PR DESCRIPTION
## Summary
- Add `VideoCaptureAllowed` / `AudioCaptureAllowed` Chromium enterprise policies restricted to localhost — enables webcam/microphone in kiosk mode without permission prompts
- Add optional `googleGeoApiKey` config field for improved geolocation accuracy (~50m vs ~5km IP fallback)
- Update CONFIG.md and config.json.example

Closes #3, closes #4