### PR TITLE
fix: change relaxSslCerts default to false and bind CDP to 127.0.0.1

### DIFF
--- a/xiboplayer/config.json
+++ b/xiboplayer/config.json
@@ -14,7 +14,7 @@
   "width": 1920,
   "height": 1080,
 
-  "relaxSslCerts": true,
+  "relaxSslCerts": false,
   "transport": "auto",
   "googleGeoApiKey": "",
 

--- a/xiboplayer/launch-kiosk.sh
+++ b/xiboplayer/launch-kiosk.sh
@@ -509,7 +509,10 @@ build_chromium_args() {
     #   systemctl --user unset-environment XIBOPLAYER_DEBUG_PORT
     #   systemctl --user restart xiboplayer-chromium
     if [[ -n "${XIBOPLAYER_DEBUG_PORT:-}" ]]; then
-        BROWSER_ARGS+=(--remote-debugging-port="$XIBOPLAYER_DEBUG_PORT")
+        BROWSER_ARGS+=(
+            --remote-debugging-port="$XIBOPLAYER_DEBUG_PORT"
+            --remote-debugging-address=127.0.0.1
+        )
         echo "[xiboplayer]   Debug:   CDP on port $XIBOPLAYER_DEBUG_PORT (127.0.0.1 only)" >&2
     fi
 


### PR DESCRIPTION
## Summary
- Default `relaxSslCerts` changed from `true` to `false` — new installs enforce TLS
- CDP debug port now explicitly binds to `127.0.0.1` via `--remote-debugging-address`

## Test plan
- [ ] New install with default config: Chromium does NOT pass `--ignore-certificate-errors`
- [ ] Config with `relaxSslCerts: true`: Chromium still passes the flag (existing behavior)
- [ ] CDP with `XIBOPLAYER_DEBUG_PORT=9222`: only reachable from localhost

Closes #31, closes #32