### PR TITLE
ci: add bats tests, concurrency group, and test gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,22 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: false
+
 jobs:
+  test:
+    name: Run bats tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get install -y bats jq
+      - name: Run tests
+        run: bats tests/launch-kiosk.bats
+
   wait-for-pwa:
     name: Wait for PWA package on npm
     runs-on: ubuntu-latest
@@ -38,8 +53,8 @@ jobs:
           exit 1
 
   rpm:
-    needs: [wait-for-pwa]
-    if: always() && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
+    needs: [test, wait-for-pwa]
+    if: always() && needs.test.result == 'success' && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
     uses: xibo-players/.github/.github/workflows/build-rpm.yml@main
     with:
       package-name: xiboplayer-chromium
@@ -53,8 +68,8 @@ jobs:
     secrets: inherit
 
   deb:
-    needs: [wait-for-pwa]
-    if: always() && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
+    needs: [test, wait-for-pwa]
+    if: always() && needs.test.result == 'success' && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
     uses: xibo-players/.github/.github/workflows/build-deb.yml@main
     with:
       package-name: xiboplayer-chromium


### PR DESCRIPTION
## Summary
- New `test` job runs `bats tests/launch-kiosk.bats` before packaging
- rpm/deb jobs now require tests to pass
- Concurrency group prevents race conditions
- 10-minute timeout on tests

Closes #37