### PR TITLE
fix: memory tiers, unclutter PID, config defaults, README service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,17 +152,17 @@ See [CONFIG.md](CONFIG.md) for full configuration reference.
 xiboplayer
 
 # Edit config
-nano ~/.config/xiboplayer/config.json
+nano ~/.config/xiboplayer/chromium/config.json
 
 # Run manually
 xiboplayer
 
 # Enable auto-start on login
-systemctl --user enable --now xiboplayer-kiosk.service
+systemctl --user enable --now xiboplayer-chromium.service
 
 # Check status / logs
-systemctl --user status xiboplayer-kiosk.service
-journalctl --user -u xiboplayer-kiosk.service -f
+systemctl --user status xiboplayer-chromium.service
+journalctl --user -u xiboplayer-chromium.service -f
 ```
 
 ## Multiple Displays
@@ -203,7 +203,7 @@ EOF
 2. Create a systemd service per instance (or use `--port` to override):
 ```bash
 # Copy and customize the service file
-cp ~/.config/systemd/user/xiboplayer-kiosk.service \
+cp ~/.config/systemd/user/xiboplayer-chromium.service \
    ~/.config/systemd/user/xiboplayer-lobby.service
 # Edit: ExecStart=/usr/bin/xiboplayer --instance=lobby
 systemctl --user enable --now xiboplayer-lobby.service

--- a/configs/chromium-dev.json
+++ b/configs/chromium-dev.json
@@ -3,7 +3,7 @@
   "cmsKey": "{{CMS_KEY}}",
   "apiClientId": "{{API_CLIENT_ID}}",
   "apiClientSecret": "{{API_CLIENT_SECRET}}",
-  "displayName": "{{DISPLAY_NAME:electron-dev}}",
+  "displayName": "{{DISPLAY_NAME:chromium-dev}}",
   "serverPort": {{PORT:8766}},
   "kioskMode": false,
   

--- a/configs/chromium-kiosk.json
+++ b/configs/chromium-kiosk.json
@@ -3,7 +3,7 @@
   "cmsKey": "{{CMS_KEY}}",
   "apiClientId": "{{API_CLIENT_ID}}",
   "apiClientSecret": "{{API_CLIENT_SECRET}}",
-  "displayName": "{{DISPLAY_NAME:electron-kiosk}}",
+  "displayName": "{{DISPLAY_NAME:chromium-kiosk}}",
   "serverPort": {{PORT:8766}},
   "kioskMode": true,
   

--- a/xiboplayer/launch-kiosk.sh
+++ b/xiboplayer/launch-kiosk.sh
@@ -144,6 +144,8 @@ cleanup() {
         rm -f "$SERVER_PID_FILE"
     fi
     rm -f "$LOCK_FILE"
+    # Kill unclutter if we started it
+    [[ -n "${UNCLUTTER_PID:-}" ]] && kill "$UNCLUTTER_PID" 2>/dev/null || true
     restore_screen_blanking
     # Kill any child processes in our process group
     kill -- -$$ 2>/dev/null || true
@@ -483,8 +485,10 @@ build_chromium_args() {
         max_old_space_mb=192; raster_threads=2
     elif (( total_ram_gb <= 4 )); then
         max_old_space_mb=256; raster_threads=$(( cpu_count < 2 ? cpu_count : 2 ))
+    elif (( total_ram_gb <= 8 )); then
+        max_old_space_mb=512; raster_threads=$(( cpu_count < 4 ? cpu_count : 4 ))
     else
-        max_old_space_mb=384; raster_threads=$(( cpu_count < 4 ? cpu_count : 4 ))
+        max_old_space_mb=768; raster_threads=$(( cpu_count < 4 ? cpu_count : 4 ))
     fi
 
     BROWSER_ARGS+=(
@@ -559,7 +563,8 @@ main() {
     if [[ "$HIDE_MOUSE_CURSOR" == "true" ]]; then
         if command -v unclutter &>/dev/null; then
             unclutter --timeout 1 --jitter 2 --hide-on-touch &
-            echo "[xiboplayer] Mouse cursor hidden (unclutter)." >&2
+            UNCLUTTER_PID=$!
+            echo "[xiboplayer] Mouse cursor hidden (unclutter, PID $UNCLUTTER_PID)." >&2
         else
             echo "[xiboplayer] WARNING: unclutter not found, cursor will be visible." >&2
             echo "[xiboplayer]   Install: sudo dnf install unclutter" >&2


### PR DESCRIPTION
Fixes 4 bugs:
- **#33**: 5th memory tier (512MB/768MB for 8GB+/16GB+ — matches Electron)
- **#34**: Track unclutter PID, kill in cleanup() (prevents orphan processes)
- **#35**: Config template defaults: electron-kiosk → chromium-kiosk
- **#36**: README: correct service name and config path

Closes #33, closes #34, closes #35, closes #36