### PR TITLE
fix: add aarch64 to RPM build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       rpm-spec: 'xiboplayer-chromium.spec'
       rpm-script: 'build-rpm.sh'
       fedora-matrix: '["43"]'
-      arch-matrix: '["x86_64"]'
+      arch-matrix: '["x86_64", "aarch64"]'
       gpg-sign: true
       publish-to-repo: true
       default-version: '0.7.13'


### PR DESCRIPTION
Chromium is noarch but repo paths are per-arch. Adds aarch64 so ARM64 users can dnf install. Refs xiboplayer-kiosk#25.