### PR TITLE
chore: remove stale default-version from workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,6 @@ jobs:
       arch-matrix: '["x86_64", "aarch64"]'
       gpg-sign: true
       publish-to-repo: true
-      default-version: '0.7.13'
     secrets: inherit
 
   deb:
@@ -78,7 +77,6 @@ jobs:
       arch-matrix: '["amd64", "arm64"]'
       gpg-sign: true
       publish-to-repo: true
-      default-version: '0.7.13'
       extra-build-deps: 'nodejs npm'
     secrets: inherit
 


### PR DESCRIPTION
Tag/spec is the source of truth.