### PR TITLE
chore: switch external deps to "latest" (keep @xiboplayer/* pinned)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "@xiboplayer/utils": "0.7.17",
     "@xiboplayer/xmds": "0.7.17",
     "@xiboplayer/xmr": "0.7.17",
-    "html2canvas": "^1.4.1",
-    "nanoevents": "^9.1.0",
-    "xml2js": "^0.6.2"
+    "html2canvas": "latest",
+    "nanoevents": "latest",
+    "xml2js": "latest"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
-    "@types/xml2js": "^0.4.14",
-    "typescript": "^5.9.3",
-    "vite": "^8.0.4"
+    "@types/node": "latest",
+    "@types/xml2js": "latest",
+    "typescript": "latest",
+    "vite": "latest"
   },
   "author": "Pau Aliagas <linuxnow@gmail.com>",
   "license": "AGPL-3.0-or-later",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,74 +9,74 @@ importers:
   .:
     dependencies:
       '@xiboplayer/cache':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/core':
-        specifier: 0.7.15
-        version: 0.7.15(@xiboplayer/cache@0.7.15)(@xiboplayer/renderer@0.7.15)(@xiboplayer/schedule@0.7.15)(@xiboplayer/xmds@0.7.15)
+        specifier: 0.7.17
+        version: 0.7.17(@xiboplayer/cache@0.7.17)(@xiboplayer/renderer@0.7.17)(@xiboplayer/schedule@0.7.17)(@xiboplayer/xmds@0.7.17)
       '@xiboplayer/crypto':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/renderer':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/schedule':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/settings':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/stats':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/sw':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/sync':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/utils':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/xmds':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       '@xiboplayer/xmr':
-        specifier: 0.7.15
-        version: 0.7.15
+        specifier: 0.7.17
+        version: 0.7.17
       html2canvas:
-        specifier: ^1.4.1
+        specifier: latest
         version: 1.4.1
       nanoevents:
-        specifier: ^9.1.0
+        specifier: latest
         version: 9.1.0
       xml2js:
-        specifier: ^0.6.2
+        specifier: latest
         version: 0.6.2
     devDependencies:
       '@types/node':
-        specifier: ^25.5.2
+        specifier: latest
         version: 25.5.2
       '@types/xml2js':
-        specifier: ^0.4.14
+        specifier: latest
         version: 0.4.14
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+        specifier: latest
+        version: 6.0.2
       vite:
-        specifier: ^8.0.7
-        version: 8.0.7(@types/node@25.5.2)
+        specifier: latest
+        version: 8.0.8(@types/node@25.5.2)
 
 packages:
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@napi-rs/canvas-android-arm64@0.1.97':
     resolution: {integrity: sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==}
@@ -107,30 +107,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-arm64-musl@0.1.97':
     resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
     resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-gnu@0.1.97':
     resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/canvas-linux-x64-musl@0.1.97':
     resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
     resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
@@ -148,106 +153,112 @@ packages:
     resolution: {integrity: sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==}
     engines: {node: '>= 10'}
 
-  '@napi-rs/wasm-runtime@1.1.2':
-    resolution: {integrity: sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==}
+  '@napi-rs/wasm-runtime@1.1.3':
+    resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.123.0':
-    resolution: {integrity: sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==}
+  '@oxc-project/types@0.124.0':
+    resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.13':
-    resolution: {integrity: sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
-    resolution: {integrity: sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
-    resolution: {integrity: sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
-    resolution: {integrity: sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
+    resolution: {integrity: sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
-    resolution: {integrity: sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
+    resolution: {integrity: sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
-    resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
-    resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
+    resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
-    resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
+    resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
-    resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
+    resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
-    resolution: {integrity: sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
+    resolution: {integrity: sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
-    resolution: {integrity: sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
-    resolution: {integrity: sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
+    resolution: {integrity: sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.13':
-    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
+  '@rolldown/pluginutils@1.0.0-rc.15':
+    resolution: {integrity: sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -258,46 +269,46 @@ packages:
   '@types/xml2js@0.4.14':
     resolution: {integrity: sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==}
 
-  '@xiboplayer/cache@0.7.15':
-    resolution: {integrity: sha512-LWg+tPDcHTI7GJMG63ct83mhqhMl1p/WaszP9S1hZKVBycDlFCrCafIyDlbezVjr5m9+vX/XvXi1d+Zq5CtKbw==}
+  '@xiboplayer/cache@0.7.17':
+    resolution: {integrity: sha512-gxhfUTzUDnKEIYmOW6NKv74yuBQGZoZV1QIb6j/If89vcPbwEfl5Hq0FVdWoLNYj39p+mCfXofXmqIwL8KtxDA==}
 
-  '@xiboplayer/core@0.7.15':
-    resolution: {integrity: sha512-jsG3WAVZVURZ2qGTsvlAY9QMNPZr9Txd3Kg80mqVlhcyE4UXXDgYKTBplE58v+LfOC2CpWHXcoFQM3tL4oag3g==}
+  '@xiboplayer/core@0.7.17':
+    resolution: {integrity: sha512-IRwcHqn3/x/9s8SNOJqCO2eXBpIC4lBQYcvoKw2iN/f4Oj6HGHtTXZhJFX0fXtGbpr+Z6lHHbKiFZPZY1TGXVQ==}
     peerDependencies:
-      '@xiboplayer/cache': 0.7.15
-      '@xiboplayer/renderer': 0.7.15
-      '@xiboplayer/schedule': 0.7.15
-      '@xiboplayer/xmds': 0.7.15
+      '@xiboplayer/cache': 0.7.17
+      '@xiboplayer/renderer': 0.7.17
+      '@xiboplayer/schedule': 0.7.17
+      '@xiboplayer/xmds': 0.7.17
 
-  '@xiboplayer/crypto@0.7.15':
-    resolution: {integrity: sha512-1MsKZfKy47+F6kBwNwSAK5dl6XJQWegKIInieBE1OBJfIroHxlL31pOfv9vg+gnJ+1ndoOFBZgvmRtY2qTRLqg==}
+  '@xiboplayer/crypto@0.7.17':
+    resolution: {integrity: sha512-ml0hwYN5d1NmCgQt16qQQFzDXWBFIjleNkTNbukA7b2dAqPQfKgo87xt4Ryka/25L3wFfJS9m3xYsq6fmTgmuA==}
 
-  '@xiboplayer/renderer@0.7.15':
-    resolution: {integrity: sha512-oYUm44P3nPF8Z6YWdj7XZyGW6+x8bF2zDvsC/2dBE0QDE0t+1ilt77mGBD+IR4GPG/rvWUIzmlOSfb+zDjeoIg==}
+  '@xiboplayer/renderer@0.7.17':
+    resolution: {integrity: sha512-ay7sgbHah0m7psl33NOkd1/Z/GUnNh+k5v6Qq9Npee/f40ccKF9CVADbH0NskDsDp++eBfxeSkR6qjtsdgJX3A==}
 
-  '@xiboplayer/schedule@0.7.15':
-    resolution: {integrity: sha512-LrDi97tiRLtiZRH0UGbI19x8Ue5l1oOp0yX9guAHDqeJucyPWqZov+27wimdLBxo4/Owv7B0U0xP4+4a2AWPnA==}
+  '@xiboplayer/schedule@0.7.17':
+    resolution: {integrity: sha512-KVy3tDi5y22XrGC5BkhRXxNFjPVMisEqUUt79VKYk9dfJCFstctPYpoxeYeum1w1q8FkvXv+lEfdYbkEettE6Q==}
 
-  '@xiboplayer/settings@0.7.15':
-    resolution: {integrity: sha512-UdAOFMTtZvyRM05OLcvwImlYFRSeyOc/sv1NpLwX/Hqya4gx+HNy9jkhiCbQXbUmtc/Bth5wPAdHkWeRNYiinw==}
+  '@xiboplayer/settings@0.7.17':
+    resolution: {integrity: sha512-40awnBEdUevkViAXml0W30EsngKjYJgi+R/yiJ4LpFiVKPRq5UkTnzlY/MlEaqeBlHg/38rcTsurKDJtEFM5Sg==}
 
-  '@xiboplayer/stats@0.7.15':
-    resolution: {integrity: sha512-vlalpCszQ64N+kKPbNKQsy4mvwIKk4I0ET2exppXk4rlIea/BxzBtt0+21I4ExAogZD/ajlthwgyPGBXxiH2pg==}
+  '@xiboplayer/stats@0.7.17':
+    resolution: {integrity: sha512-GfwMAG1ltuNE9b/chKJNpUT47PgwktDNmDXezUK/UGnphIRRPNWlLAh4VLlAX5kisA9ADLZEYog1XtS4PWe28Q==}
 
-  '@xiboplayer/sw@0.7.15':
-    resolution: {integrity: sha512-kmskUUDul/B4Gs6ua3/VxBstizkfhqqJGIF3nLa/xwvLDP15KunilOeJCMrz/4qVI1fINxE7AUErFSA97wQ2Lw==}
+  '@xiboplayer/sw@0.7.17':
+    resolution: {integrity: sha512-o/CWNZV17PH+ThAXbA1XW3HJpw8H+IhGRUVkwrsnaXgnVxO33tqpMuZmJS/A0u4rkGJjgSFy/f/mwMmtqOs3Vw==}
 
-  '@xiboplayer/sync@0.7.15':
-    resolution: {integrity: sha512-sfTxKlqTXCN0sz2X53JEzX2UBkTmTm5tv1a9mnX8i7vPff2ALft5rpUkx6Le3RMAok+lpkTgbcgRDpT9zXr0gw==}
+  '@xiboplayer/sync@0.7.17':
+    resolution: {integrity: sha512-MAMf7qW0jWT2KpiPyMSirgtTqFTxYIgNuac6HSkvTI4ocfzfPsit+aOmI672GGkq7BBRmQO1rLYg9Y1MfpED1w==}
 
-  '@xiboplayer/utils@0.7.15':
-    resolution: {integrity: sha512-7nj+zquciP6ZtTXJS9dehkYhnLYZdUWoMDxPhI36No7aHwgKdPjyZxzIFrjc1ST9lnIJIvs1IbX8xeC9QdqccA==}
+  '@xiboplayer/utils@0.7.17':
+    resolution: {integrity: sha512-9LpmN+56VeY6VH21e33em8AXQCXAfHpc886u26qEU1HjXApaDLxnfahiU+ing9OiQyKc1uADJfkEQwFeRtBbKg==}
 
-  '@xiboplayer/xmds@0.7.15':
-    resolution: {integrity: sha512-/fmQlnPQkMuhlWsHE+pcOpvSwTJEjFBKRNQANSV3ICZEaVr8rjXPQLFgrJTCV9kOfxksRFbzq3xGgHhbOwfwyw==}
+  '@xiboplayer/xmds@0.7.17':
+    resolution: {integrity: sha512-E1OwqOKBF1uYZB8MXzG5ndYw9v0HHgycasXk/F2rftP6rqgqrxrv07XlyKgCdPGhcw6un/ZGoChJfRXR9O9rTw==}
 
-  '@xiboplayer/xmr@0.7.15':
-    resolution: {integrity: sha512-N8E2eQkMM6pCerSeiYcjeCO5iSlZXLzCulD1sZuezZvnalU1CQ1x7JYnAMsGjDfTf3Y75HdpxebjAcVJsQgyQA==}
+  '@xiboplayer/xmr@0.7.17':
+    resolution: {integrity: sha512-l3LvY1AkTqnrFp3lVjfLnbi5wlXFfO1XUXYoBO38QmNa7EZTKZz99PRfJ5r9DntrWk9WnKrdbJ41ElgGstO2Vw==}
 
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
@@ -363,24 +374,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -421,12 +436,12 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.9:
+    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
     engines: {node: ^10 || ^12 || >=14}
 
-  rolldown@1.0.0-rc.13:
-    resolution: {integrity: sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==}
+  rolldown@1.0.0-rc.15:
+    resolution: {integrity: sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -444,15 +459,15 @@ packages:
   text-segmentation@1.0.3:
     resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.2:
+    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -462,8 +477,8 @@ packages:
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
-  vite@8.0.7:
-    resolution: {integrity: sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==}
+  vite@8.0.8:
+    resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -515,18 +530,18 @@ packages:
 
 snapshots:
 
-  '@emnapi/core@1.9.1':
+  '@emnapi/core@1.9.2':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -579,65 +594,65 @@ snapshots:
       '@napi-rs/canvas-win32-x64-msvc': 0.1.97
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@oxc-project/types@0.123.0': {}
+  '@oxc-project/types@0.124.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.13':
+  '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.13':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.13':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.13':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.13':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.15':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
-      '@napi-rs/wasm-runtime': 1.1.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.13':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.15':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.13': {}
+  '@rolldown/pluginutils@1.0.0-rc.15': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -652,60 +667,60 @@ snapshots:
     dependencies:
       '@types/node': 25.5.2
 
-  '@xiboplayer/cache@0.7.15':
+  '@xiboplayer/cache@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
       spark-md5: 3.0.2
 
-  '@xiboplayer/core@0.7.15(@xiboplayer/cache@0.7.15)(@xiboplayer/renderer@0.7.15)(@xiboplayer/schedule@0.7.15)(@xiboplayer/xmds@0.7.15)':
+  '@xiboplayer/core@0.7.17(@xiboplayer/cache@0.7.17)(@xiboplayer/renderer@0.7.17)(@xiboplayer/schedule@0.7.17)(@xiboplayer/xmds@0.7.17)':
     dependencies:
-      '@xiboplayer/cache': 0.7.15
-      '@xiboplayer/renderer': 0.7.15
-      '@xiboplayer/schedule': 0.7.15
-      '@xiboplayer/utils': 0.7.15
-      '@xiboplayer/xmds': 0.7.15
+      '@xiboplayer/cache': 0.7.17
+      '@xiboplayer/renderer': 0.7.17
+      '@xiboplayer/schedule': 0.7.17
+      '@xiboplayer/utils': 0.7.17
+      '@xiboplayer/xmds': 0.7.17
 
-  '@xiboplayer/crypto@0.7.15': {}
+  '@xiboplayer/crypto@0.7.17': {}
 
-  '@xiboplayer/renderer@0.7.15':
+  '@xiboplayer/renderer@0.7.17':
     dependencies:
-      '@xiboplayer/cache': 0.7.15
-      '@xiboplayer/schedule': 0.7.15
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/cache': 0.7.17
+      '@xiboplayer/schedule': 0.7.17
+      '@xiboplayer/utils': 0.7.17
       pdfjs-dist: 5.6.205
 
-  '@xiboplayer/schedule@0.7.15':
+  '@xiboplayer/schedule@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
 
-  '@xiboplayer/settings@0.7.15':
+  '@xiboplayer/settings@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
 
-  '@xiboplayer/stats@0.7.15':
+  '@xiboplayer/stats@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
 
-  '@xiboplayer/sw@0.7.15':
+  '@xiboplayer/sw@0.7.17':
     dependencies:
-      '@xiboplayer/cache': 0.7.15
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/cache': 0.7.17
+      '@xiboplayer/utils': 0.7.17
 
-  '@xiboplayer/sync@0.7.15':
+  '@xiboplayer/sync@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
 
-  '@xiboplayer/utils@0.7.15':
+  '@xiboplayer/utils@0.7.17':
     dependencies:
-      '@xiboplayer/crypto': 0.7.15
+      '@xiboplayer/crypto': 0.7.17
 
-  '@xiboplayer/xmds@0.7.15':
+  '@xiboplayer/xmds@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
 
-  '@xiboplayer/xmr@0.7.15':
+  '@xiboplayer/xmr@0.7.17':
     dependencies:
-      '@xiboplayer/utils': 0.7.15
+      '@xiboplayer/utils': 0.7.17
 
   base64-arraybuffer@1.0.2: {}
 
@@ -792,32 +807,32 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.8:
+  postcss@8.5.9:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  rolldown@1.0.0-rc.13:
+  rolldown@1.0.0-rc.15:
     dependencies:
-      '@oxc-project/types': 0.123.0
-      '@rolldown/pluginutils': 1.0.0-rc.13
+      '@oxc-project/types': 0.124.0
+      '@rolldown/pluginutils': 1.0.0-rc.15
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.13
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.13
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.13
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.13
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.13
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.13
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.13
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.13
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.13
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.13
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.13
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.13
+      '@rolldown/binding-android-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.15
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.15
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.15
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.15
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.15
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.15
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.15
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
   sax@1.6.0: {}
 
@@ -829,7 +844,7 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -837,7 +852,7 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   undici-types@7.18.2: {}
 
@@ -845,13 +860,13 @@ snapshots:
     dependencies:
       base64-arraybuffer: 1.0.2
 
-  vite@8.0.7(@types/node@25.5.2):
+  vite@8.0.8(@types/node@25.5.2):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
-      rolldown: 1.0.0-rc.13
-      tinyglobby: 0.2.15
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.5.2
       fsevents: 2.3.3


### PR DESCRIPTION
Part 3/3 of the ecosystem-wide "latest" rollout. See xibo-players/xiboplayer-ai#52 for the pattern and the two earlier downstream PRs (xibo-players/xiboplayer-smil-tools#13, xibo-players/xiboplayer-electron#48).

**External deps** → `"latest"`:
- `html2canvas`, `nanoevents`, `xml2js`, `@types/node`, `@types/xml2js`, `typescript`, `vite`

**Internal deps** → stay pinned:
- All 12 `@xiboplayer/*` deps at the root (and the nested `xiboplayer/server/package.json`) stay at exact `0.7.17` for `release-xiboplayer.yml` regex compatibility.

## TypeScript 6.0.2 note

TS 5 → 6 is technically a major bump. This repo contains **zero `.ts` files** — the TypeScript dependency is declared but not consumed by any build step here (only shell scripts + one `.js` file in `xiboplayer/server/server.js`, plus bats tests). Safe to accept.

## Test plan

- [x] `pnpm install` — 1.8s, no errors
- [x] No `.ts` files → nothing to type-check
- [x] No `pnpm test` script — chromium uses bats tests (`launch-kiosk.bats`)
- [ ] RPM build not run locally; validated by the Build Chromium Kiosk workflow on tag push