### PR TITLE
chore: unbump 0.7.20 → 0.7.19 so playbook can bump SDK+players in lockstep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xiboplayer/pwa",
-  "version": "0.7.20",
+  "version": "0.7.19",
   "description": "Lightweight PWA xiboplayer with RendererLite",
   "type": "module",
   "files": [

--- a/xiboplayer-chromium.spec
+++ b/xiboplayer-chromium.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           xiboplayer-chromium
-Version:        0.7.20
+Version:        0.7.19
 Release:        1%{?dist}
 Summary:        Self-contained Xibo digital signage player (Chromium kiosk)
 
@@ -131,9 +131,6 @@ if [ $1 -eq 0 ] ; then
 fi
 
 %changelog
-* Thu Apr 16 2026 Pau Aliagas <linuxnow@gmail.com> - 0.7.20-1
-- GPU detection: virtio-gpu / QEMU / VMware SVGA force software rendering to avoid crash loop (MODE_CREATE_DUMB EACCES). Real GPUs unchanged.
-
 * Tue Apr 14 2026 Pau Aliagas <linuxnow@gmail.com> - 0.7.19-1
 - Stability fixes + chromium instrumentation: proxy crash on closed client stream, stale-cache age log calculation, chromium launcher renderer log forwarding, SECURITY.md, SBOM CI.
 


### PR DESCRIPTION
Reverts the version-only parts of #74 so release-xiboplayer.yml has something to bump on next invocation. GPU-detection code stays. Companion unbump PR for xiboplayer-electron.