### PR TITLE
fix(gpu): lower best_rank init so virtio (rank -1) can be selected

### DIFF
--- a/xiboplayer/launch-kiosk.sh
+++ b/xiboplayer/launch-kiosk.sh
@@ -289,7 +289,7 @@ start_server() {
 detect_and_select_gpu() {
     local pref="${GPU_PREFERENCE:-${XIBO_GPU:-auto}}"
     local -a gpu_names=() gpu_vendors=() gpu_render_nodes=() gpu_ranks=() gpu_va_drivers=() gpu_has_display=() gpu_is_virtual=()
-    local best_idx=-1 best_rank=-1
+    local best_idx=-1 best_rank=-99
 
     for card_dir in /sys/class/drm/card[0-9]*; do
         [[ -d "$card_dir/device" ]] || continue


### PR DESCRIPTION
One-line fix to the 0.7.20 virtual-GPU detection. The selection loop init was best_rank=-1 and virtio rank is -1, so the strict > comparison never picks virtio. Change init to -99. Verified the fix logic flow end-to-end.

Bug discovered by Pau's fresh test install: chromium still crash-loops under Boxes despite 0.7.20 being installed. Root cause is this selection-loop arithmetic edge case, not the detection change itself.