### PR TITLE
chore: post-rename sweep — xibo-players → xiboplayer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
   rpm:
     needs: [test, wait-for-pwa]
     if: always() && needs.test.result == 'success' && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
-    uses: xibo-players/.github/.github/workflows/build-rpm.yml@b32631e9f28d649efea2873282c79bb439c13751  # main
+    uses: xiboplayer/.github/.github/workflows/build-rpm.yml@b32631e9f28d649efea2873282c79bb439c13751  # main
     with:
       package-name: xiboplayer-chromium
       rpm-spec: 'xiboplayer-chromium.spec'
@@ -74,7 +74,7 @@ jobs:
   deb:
     needs: [test, wait-for-pwa]
     if: always() && needs.test.result == 'success' && (needs.wait-for-pwa.result == 'success' || needs.wait-for-pwa.result == 'skipped')
-    uses: xibo-players/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
+    uses: xiboplayer/.github/.github/workflows/build-deb.yml@99b65f33c5227c49a8f093cb776894ef82e4d77e  # main
     with:
       package-name: xiboplayer-chromium
       deb-script: 'build-deb.sh'
@@ -87,7 +87,7 @@ jobs:
 
   release:
     needs: [rpm, deb]
-    uses: xibo-players/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
+    uses: xiboplayer/.github/.github/workflows/create-release.yml@5c3b3699cd05c12bb3ec76e5d1d317d539dd69b4  # main
     with:
       package-name: xiboplayer-chromium
       description: 'Chromium kiosk-mode Xibo digital signage player.'

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If no config file is present, Chromium opens the PWA setup page where you enter 
 
 ### Auto-authorize via CMS API (optional)
 
-By default, new displays must be manually authorized by a CMS administrator. To skip this step, add OAuth2 API credentials to `config.json` — see the [PWA README](https://github.com/xibo-players/xiboplayer-pwa#auto-authorize-via-cms-api-optional) for full setup instructions including CMS Application configuration:
+By default, new displays must be manually authorized by a CMS administrator. To skip this step, add OAuth2 API credentials to `config.json` — see the [PWA README](https://github.com/xiboplayer/xiboplayer-pwa#auto-authorize-via-cms-api-optional) for full setup instructions including CMS Application configuration:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/xibo-players/xiboplayer-pwa.git"
+    "url": "git+https://github.com/xiboplayer/xiboplayer-pwa.git"
   },
   "homepage": "https://xiboplayer.org"
 }

--- a/xiboplayer/xiboplayer-chromium.service
+++ b/xiboplayer/xiboplayer-chromium.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Xibo Digital Signage Player (Chromium Kiosk)
-Documentation=https://github.com/xibo-players/xiboplayer-chromium
+Documentation=https://github.com/xiboplayer/xiboplayer-chromium
 After=graphical-session.target
 Wants=graphical-session.target
 PartOf=graphical-session.target


### PR DESCRIPTION
## Summary

3 files updated post-rename. package.json repo URL, build workflow `uses:`, systemd service file.

## Intentionally NOT touched

- `xiboplayer-chromium.spec` changelog entry citing `xibo-players/xiboplayer#332` — don't rewrite history.
- `README.md` instructions referencing `xibo-players.gpg` / `xibo-players.sources` — these are file paths on dl.xiboplayer.org; renaming would break existing user installations that have those exact files in /etc/apt/keyrings/ and /etc/apt/sources.list.d/. Separate fleet-coordinated rename if/when desired.
- Lockfiles, node_modules, dist.

## Refs

Companion to xiboplayer/xiboplayer-www#60, xiboplayer/xiboplayer-electron, xiboplayer/xiboplayer-kiosk#201, xiboplayer/.github#42.